### PR TITLE
added protobuf 3.0.2 recipe

### DIFF
--- a/protobuf-3.0.2/build.sh
+++ b/protobuf-3.0.2/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sh autogen.sh
+./configure --prefix=$PREFIX
+
+C_INCLUDE_PATH=$PREFIX/include make
+C_INCLUDE_PATH=$PREFIX/include make install
+
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2
+
+cd python
+C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib python setup.py build --cpp_implementation
+C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib python setup.py install --cpp_implementation

--- a/protobuf-3.0.2/meta.yaml
+++ b/protobuf-3.0.2/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: protobuf
+  version: 3.0.2
+
+source:
+  git_url: https://github.com/google/protobuf
+  git_tag: v3.0.2
+
+requirements:
+  build:
+    - automake
+    - libtool
+    - pkg-config
+    - python
+    - cython
+    - setuptools
+    - google-apputils
+
+  run:
+
+    - python
+    - cython
+    - google-apputils
+
+about:
+  home: https://developers.google.com/protocol-buffers/
+  license:  BSD 3-clause


### PR DESCRIPTION
@wkirwin @sstirlin @johnistan  Conda recipe for protobuf 3.0.2.  I've already built and uploaded both os x and linux tarballs to our ActivisionGameScience conda repository here:

https://anaconda.org/ActivisionGameScience/protobuf/files
